### PR TITLE
PQ-4: Adding condition to avoid completion of queue that is being created

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientqueueing/api/impl/PatientQueueingServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientqueueing/api/impl/PatientQueueingServiceImpl.java
@@ -36,7 +36,7 @@ public class PatientQueueingServiceImpl extends BaseOpenmrsService implements Pa
     public PatientQueue savePatientQue(PatientQueue patientQueue) {
         PatientQueue currentQueue = dao.getIncompletePatientQueue(patientQueue.getPatient(), patientQueue.getLocationTo());
 
-        if (currentQueue != null) {
+        if (currentQueue != null && !patientQueue.equals(currentQueue)) {
             completePatientQueue(currentQueue);
         }
 

--- a/api/src/test/java/org/openmrs/module/patientqueueing/api/PatientQueueingServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/patientqueueing/api/PatientQueueingServiceTest.java
@@ -40,8 +40,8 @@ public class PatientQueueingServiceTest extends BaseModuleContextSensitiveTest {
 
 	private static Logger logger = LoggerFactory.getLogger(PatientQueueingServiceTest.class);
 
-    private static final Integer QUEUE_PRIORITY_ZERO=0;
-    private static final Integer QUEUE_PRIORITY_ONE=1;
+    private static final Integer QUEUE_PRIORITY_ZERO = 0;
+    private static final Integer QUEUE_PRIORITY_ONE = 1;
 
 	@Before
 	public void initialize() throws Exception {

--- a/api/src/test/java/org/openmrs/module/patientqueueing/api/PatientQueueingServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/patientqueueing/api/PatientQueueingServiceTest.java
@@ -40,8 +40,8 @@ public class PatientQueueingServiceTest extends BaseModuleContextSensitiveTest {
 
 	private static Logger logger = LoggerFactory.getLogger(PatientQueueingServiceTest.class);
 
-    private static final int QUEUE_PRIORITY_ZERO=0;
-    private static final int QUEUE_PRIORITY_ONE=1;
+    private static final Integer QUEUE_PRIORITY_ZERO=0;
+    private static final Integer QUEUE_PRIORITY_ONE=1;
 
 	@Before
 	public void initialize() throws Exception {
@@ -283,7 +283,7 @@ public class PatientQueueingServiceTest extends BaseModuleContextSensitiveTest {
 
         PatientQueue editedPatientQueue = patientQueueingService.savePatientQue(patientQueueToEdit);
 
-        Assert.assertEquals(QUEUE_PRIORITY_ONE, editedPatientQueue.getPriority().intValue());
+        Assert.assertEquals(QUEUE_PRIORITY_ONE, editedPatientQueue.getPriority());
         Assert.assertEquals("Non-Emergency", editedPatientQueue.getPriorityComment());
         Assert.assertEquals(PatientQueue.Status.PENDING, editedPatientQueue.getStatus());
     }

--- a/api/src/test/java/org/openmrs/module/patientqueueing/api/PatientQueueingServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/patientqueueing/api/PatientQueueingServiceTest.java
@@ -37,9 +37,12 @@ import java.util.List;
 public class PatientQueueingServiceTest extends BaseModuleContextSensitiveTest {
 	
 	private static final String QUEUE_STANDARD_DATASET_XML = "org/openmrs/module/patientqueueing/standardTestDataset.xml";
-	
+
 	private static Logger logger = LoggerFactory.getLogger(PatientQueueingServiceTest.class);
-	
+
+    private static final int QUEUE_PRIORITY_ZERO=0;
+    private static final int QUEUE_PRIORITY_ONE=1;
+
 	@Before
 	public void initialize() throws Exception {
 		executeDataSet(QUEUE_STANDARD_DATASET_XML);
@@ -252,4 +255,36 @@ public class PatientQueueingServiceTest extends BaseModuleContextSensitiveTest {
 		Assert.assertEquals(patientQueue, patientQueueingService.getMostRecentQueue(patient));
 		
 	}
+
+    @Test
+    public void savePatientQueue_shouldNotCompletePatientQueueOnEdit() throws Exception {
+
+        PatientQueueingService patientQueueingService = Context.getService(PatientQueueingService.class);
+
+        Patient patient = Context.getPatientService().getPatient(10000);
+
+        Location location = Context.getLocationService().getLocation(1);
+
+        PatientQueue patientQueue = new PatientQueue();
+        patientQueue.setPatient(patient);
+        patientQueue.setStatus(PatientQueue.Status.PENDING);
+        patientQueue.setEncounter(Context.getEncounterService().getEncounter(10000));
+        patientQueue.setLocationFrom(location);
+        patientQueue.setLocationTo(location);
+        patientQueue.setPriority(QUEUE_PRIORITY_ZERO);
+        patientQueue.setPriorityComment("Emergency");
+        patientQueueingService.assignVisitNumberForToday(patientQueue);
+        patientQueueingService.savePatientQue(patientQueue);
+
+        PatientQueue patientQueueToEdit = patientQueueingService.getPatientQueueById(patientQueue.getPatientQueueId());
+
+        patientQueueToEdit.setPriority(QUEUE_PRIORITY_ONE);
+        patientQueueToEdit.setPriorityComment("Non-Emergency");
+
+        PatientQueue editedPatientQueue = patientQueueingService.savePatientQue(patientQueueToEdit);
+
+        Assert.assertEquals(QUEUE_PRIORITY_ONE, editedPatientQueue.getPriority().intValue());
+        Assert.assertEquals("Non-Emergency", editedPatientQueue.getPriorityComment());
+        Assert.assertEquals(PatientQueue.Status.PENDING, editedPatientQueue.getStatus());
+    }
 }


### PR DESCRIPTION
A logical bug was discovered. During edit of a patientQueue the queue gets completed automatically which is not a desired behaviour. This change ensures that it doesn't happen
https://issues.openmrs.org/projects/PQ/issues/PQ-4